### PR TITLE
Fix vtest for v 0.24

### DIFF
--- a/vtest.v
+++ b/vtest.v
@@ -74,7 +74,7 @@ fn build_diff(left_input string, right_input string) string {
         if left[i] == right[i] {
             left_diff += left[i].str()
             right_diff += right[i].str()
-            i += 1
+            i++
             continue
         }
 
@@ -84,7 +84,7 @@ fn build_diff(left_input string, right_input string) string {
         for i < min_length && left[i] != right[i] {
             left_current_diff += left[i].str()
             right_current_diff += right[i].str()
-            i += 1
+            i++
         }
 
         left_diff += term.green(left_current_diff)


### PR DESCRIPTION
Breaks in 0.24 with:

```
Testing...
FAIL    82 ms [1/2] modules/vtest/vtest_test.v
`/workspace/smatch/modules/vtest/vtest_test.v`
 (
modules/vtest/vtest.v:77:16: use `++` instead of `+= 1`
   75|             left_diff += left[i].str()
   76|             right_diff += right[i].str()
   77|             i += 1
                      ^
   78|             continue
   79|         }
)
FAIL   224 ms [2/2] smatch_test.v
`/workspace/smatch/smatch_test.v`
 (
modules/vtest/vtest.v:77:16: use `++` instead of `+= 1`
   75|             left_diff += left[i].str()
   76|             right_diff += right[i].str()
   77|             i += 1
                      ^
   78|             continue
   79|         }
)
------------------------------------------------------------------------------------------------------------------------------------------------------------------------
     306 ms <=== total time spent running V _test.v files
                 ok, fail, total =     0,     2,     2
```